### PR TITLE
Adds a cpf input format validation

### DIFF
--- a/lib/cpf_validator.dart
+++ b/lib/cpf_validator.dart
@@ -49,13 +49,23 @@ class CPFValidator {
   }
 
   static String strip(String cpf) {
-    RegExp regex = RegExp(STRIP_REGEX);
+    RegExp regExp = RegExp(STRIP_REGEX);
     cpf = cpf == null ? "" : cpf;
 
-    return cpf.replaceAll(regex, "");
+    return cpf.replaceAll(regExp, "");
+  }
+
+  static bool validateInputFormat(String cpf) {
+    RegExp regExp = RegExp(r'^(\d{3}.\d{3}.\d{3}-\d{2})|(\d{11})$');
+
+    return regExp.hasMatch(cpf);
   }
 
   static bool isValid(String cpf) {
+    if (!validateInputFormat(cpf)) {
+      return false;
+    }
+
     String stripped = strip(cpf);
 
     // CPF must be defined

--- a/test/cpf_test.dart
+++ b/test/cpf_test.dart
@@ -8,6 +8,8 @@ void main() {
     expect(CPFValidator.isValid("35999906032"), true);
     expect(CPFValidator.isValid("35999906031"), false);
     expect(CPFValidator.isValid("033461671002"), false);
+    expect(CPFValidator.isValid("033461671002@mail"), false);
+    expect(CPFValidator.isValid("03.3461.67100-2"), false);
 
     List<String> blackListed = [
       "00000000000",


### PR DESCRIPTION
I experienced a validation problem when submitting wrong cpfs (like 57abc803.6586-52 and 5780test3658652@mail.com), the plugin returned true. So, I added an extra validation.

Best Regards