### PR TITLE
Make this library Dart-pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.1.0
+
+* Remove hard dependency of Flutter.
+* Move `test` package dependency to `dev_dependencies`.
+
 ## v1.0.0
 
 This release includes:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: example
 description: An example of how to use Flutter plugin CPF&#x2F;CNPJ validator.
-publish_to: 'none' #Remove this line if you wish to publish in pub.dev
+publish_to: "none" #Remove this line if you wish to publish in pub.dev
 
 version: 1.0.0+1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,10 @@
 name: cpf_cnpj_validator
 description: A lib to validate, format, strip and generate CPF and CNPJ numbers from Brazil.
-version: 2.0.0-nullsafety
+version: 2.1.0-nullsafety
 homepage: https://github.com/leonardocaldas/flutter-cpf-cnpj-validator
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
-dependencies:
-  flutter:
-    sdk: flutter
-  flutter_test:
-    sdk: flutter
+dev_dependencies:
+  test: ^1.17.10

--- a/test/cnpj_test.dart
+++ b/test/cnpj_test.dart
@@ -1,5 +1,5 @@
 import 'package:cpf_cnpj_validator/cnpj_validator.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test("Test CNPJ validator", () {

--- a/test/cpf_test.dart
+++ b/test/cpf_test.dart
@@ -1,5 +1,5 @@
 import 'package:cpf_cnpj_validator/cpf_validator.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test("Test CPF validator", () {


### PR DESCRIPTION
There's no reason for this library to depend on Flutter (as it only uses `dart:math`) so I'm removing the hard dependency, and moving the `test` dependency to `dev_dependencies`.

* Remove hard dependency of Flutter.
* Move `test` package dependency to `dev_dependencies`.